### PR TITLE
Removes dependancy on kitty

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ REST client for [kakoune](https://github.com/mawww/kakoune/), highly inspired by
 
 ## Requirements
 
-- [kitty](https://github.com/kovidgoyal/kitty) terminal to create a split window
 - `python`
 - `xclip` to copy request as cURL command
 

--- a/restclient.kak
+++ b/restclient.kak
@@ -80,7 +80,7 @@ print(data[0])
         try %{
             evaluate-commands -client kak-restclient-response edit!
         } catch %{
-            new "rename-client kak-restclient-response; edit /tmp/kak-restclient/%val{session}.json"
+            new "rename-client kak-restclient-response; edit /tmp/kak-restclient/%val{session}.json; set-option buffer autoreload true"
         }
 
         evaluate-commands -draft %{

--- a/restclient.kak
+++ b/restclient.kak
@@ -80,13 +80,7 @@ print(data[0])
         try %{
             evaluate-commands -client kak-restclient-response edit!
         } catch %{
-            nop %sh{
-                kitty @ new-window --no-response --window-type os kak -c "${kak_session}" -e "
-                rename-client kak-restclient-response
-                edit /tmp/kak-restclient/${kak_session}.json
-                "
-                kitty @ focus-window --no-response --match id:"${KITTY_WINDOW_ID}"
-            }
+            new "rename-client kak-restclient-response; edit /tmp/kak-restclient/%val{session}.json"
         }
 
         evaluate-commands -draft %{


### PR DESCRIPTION
Instead of adding hard dependency on kitty, this PR suggests using the `new` command. 
This allows users to use any terminal that works with kakoune.

Additionally enables autoreload in the response buffer.